### PR TITLE
Fix CreateMatrix validation

### DIFF
--- a/matrix.go
+++ b/matrix.go
@@ -12,7 +12,7 @@ type Matrix struct {
 
 func CreateMatrix(rows int, cols int, elements []float64) *Matrix {
 
-	if rows < 0 || cols < 0 {
+	if rows <= 0 || cols <= 0 {
 		log.Panic("The rows and cols must be greater or equal to 1")
 	}
 


### PR DESCRIPTION
Fix `CreateMatrix` where call with `rows` or `cols` equals `0`.